### PR TITLE
feat: change assets data structure for including some metadata

### DIFF
--- a/folio-board/components/commons/FileInput.jsx
+++ b/folio-board/components/commons/FileInput.jsx
@@ -10,9 +10,10 @@ export const FileInput = React.forwardRef((props, ref) => (
         onChange={event => {
             const selectedFile = event.target.files?.[0];
             if (selectedFile) {
+                const type = selectedFile.type;
                 blobToDataUrl(selectedFile).then(data => {
                     event.target.value = "";
-                    props.onFile?.(data);
+                    props.onFile?.(data, type);
                 });
             }
         }}

--- a/folio-board/components/commons/Layout.jsx
+++ b/folio-board/components/commons/Layout.jsx
@@ -162,8 +162,8 @@ export const Layout = props => {
             <FileInput
                 ref={imageInputRef}
                 accept="image/*"
-                onFile={fileData => {
-                    board.addImage(fileData).then(() => {
+                onFile={(data, type) => {
+                    board.addImage(data, type).then(() => {
                         props.onChange?.({
                             elements: board.elements,
                             assets: board.assets,

--- a/folio-core/elements/ImageElement.jsx
+++ b/folio-core/elements/ImageElement.jsx
@@ -3,10 +3,8 @@ import {useAssets} from "../contexts/AssetsContext.jsx";
 
 export const ImageElement = props => {
     const assets = useAssets();
-    // const x = Math.min(props.x1, props.x2);
-    // const y = Math.min(props.y1, props.y2);
-    // const width = Math.abs(props.x2 - props.x1);
-    // const height = Math.abs(props.y2 - props.y1);
+    const dataUrl = assets[props.assetId]?.dataUrl || "";
+
     return (
         <g transform="">
             <image
@@ -15,7 +13,7 @@ export const ImageElement = props => {
                 y={Math.min(props.y1, props.y2)}
                 width={Math.abs(props.x2 - props.x1)}
                 height={Math.abs(props.y2 - props.y1)}
-                href={assets[props.assetId] || ""}
+                href={dataUrl}
                 onPointerDown={props.onPointerDown}
                 onDoubleClick={props.onDoubleClick}
             />


### PR DESCRIPTION
This PR improves the current assets data structure for including some metadata. The new data structure will be:

```js
const asset = {
    id: "123456",
    type: "image/png",
    createdAt: 123456,
    dataUrl: "",
};
```
